### PR TITLE
fix(backstage-techdocs): remove techdocs reference

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,7 +5,6 @@ metadata:
   description: "test3"
   annotations:
     github.com/project-slug: cultureamp/mt-test-3
-    backstage.io/techdocs-ref: url:https://github.com/cultureamp/mt-test-3
     buildkite.com/project-slug: culture-amp/mt-test-3
 spec:
   type: service


### PR DESCRIPTION
Remove the references to non-existent backstage tech docs files.

References to non-existent files causes backstage 404.